### PR TITLE
Add gsettings override (previously in system76-driver)

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -3,3 +3,5 @@
 %:
 	dh $@
 
+override_dh_installgsettings:
+	dh_installgsettings --priority=40

--- a/debian/system76-wallpapers.gsettings-override
+++ b/debian/system76-wallpapers.gsettings-override
@@ -1,0 +1,2 @@
+[org.gnome.desktop.background]
+picture-uri = 'file:///usr/share/backgrounds/System76-Fractal_Mountains-by_Kate_Hazen_of_System76.png'


### PR DESCRIPTION
This moves the gsettings override into the wallpapers package, so it will only be applied if the wallpapers package is being installed. (This allows removing the wallpapers package or installing `system76-driver` without it using `--no-recommends`.)