### PR TITLE
fix: Update gsettings override for 24.04

### DIFF
--- a/debian/system76-wallpapers.gsettings-override
+++ b/debian/system76-wallpapers.gsettings-override
@@ -1,2 +1,3 @@
-[org.gnome.desktop.background]
+[org.gnome.desktop.background:ubuntu]
 picture-uri = 'file:///usr/share/backgrounds/System76-Fractal_Mountains-by_Kate_Hazen_of_System76.png'
+picture-uri-dark = 'file:///usr/share/backgrounds/System76-Fractal_Mountains-by_Kate_Hazen_of_System76.png'


### PR DESCRIPTION
This is the commit where Ubuntu added the `:ubuntu` session selector to their default setting, at the start of 23.04 development: https://git.launchpad.net/ubuntu/+source/ubuntu-settings/commit/?h=applied/ubuntu/noble&id=b8c72dd2331d40b43a865bf3e38d7a3d3b11dde4 

The session selector means their override (while limited to the default Ubuntu session) is more specific than ours was, and therefore took precedence. This adds the session selector to our override, making it work again.

I've also set the corresponding dark mode preference; while not the default color scheme, I don't see why the behavior should differ based on the active color scheme. (If someone has set a wallpaper manually, this default override will still defer to their custom setting.)

This does still require a session restart to take effect in 24.04 (I don't think that's always been the case, but looks like it was in 22.04 even with our released version, so it's not a recent regression). I confirmed this updated version still takes effect on a fresh install of 22.04, so there's no need to branch off a `master_jammy`.